### PR TITLE
[NOT MERGE] Http requests and responses contain activity ids

### DIFF
--- a/src/Poc.Sl.HttpSenderApp/Program.cs
+++ b/src/Poc.Sl.HttpSenderApp/Program.cs
@@ -9,7 +9,18 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 // add http client and httplogger
-builder.Services.AddHttpClient();
+builder.Services.AddHttpClient("bingClient", httpClient => 
+{
+    httpClient.DefaultRequestHeaders.Add("my-custom-header", "my-value");
+});
+
+builder.Services.AddHttpClient("multipleClient", httpClient =>
+{
+    httpClient.DefaultRequestHeaders.Add("my-custom-header-1", "my-value-1");
+    httpClient.DefaultRequestHeaders.Add("my-custom-header-2", "my-value-2");
+    httpClient.DefaultRequestHeaders.Add("my-custom-header-3", "my-value-3");
+});
+
 builder.Services.AddHttpLogging(options => 
 {
     options.LoggingFields = HttpLoggingFields.All;
@@ -28,8 +39,10 @@ app.UseHttpLogging();
 
 app.UseHttpsRedirection();
 
-app.MapGet("/bing", async (HttpClient httpClient) =>
+app.MapGet("/bing", async (IHttpClientFactory factory) =>
 {
+    var httpClient = factory.CreateClient("bingClient");
+
     httpClient.DefaultRequestHeaders.Add("my-custom-header", "my-value");
 
     // make http get request to bing
@@ -47,8 +60,10 @@ app.MapGet("/bing", async (HttpClient httpClient) =>
 });
 
 
-app.MapGet("/bing-and-google", async (HttpClient httpClient) =>
+app.MapGet("/bing-and-google", async (IHttpClientFactory factory) =>
 {
+    var httpClient = factory.CreateClient("multipleClient");
+
     httpClient.DefaultRequestHeaders.Add("my-custom-header-1", "my-value-1");
     httpClient.DefaultRequestHeaders.Add("my-custom-header-2", "my-value-2");
     httpClient.DefaultRequestHeaders.Add("my-custom-header-3", "my-value-3");

--- a/src/Poc.Sl.LoggerApp/AspnetCoreEventParserHelper.cs
+++ b/src/Poc.Sl.LoggerApp/AspnetCoreEventParserHelper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Poc.Sl.LoggerApp
+{
+    internal static class AspnetCoreEventParserHelper
+    {
+        public static string LoggerName => "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware";
+
+        public static string EventName => "MessageJson";
+
+        public static void Parse(TraceEvent traceEvent)
+        {
+            // if you run the app via VS -> for responce's activity ids will be incorrect.
+            var eventId = Convert.ToInt32(traceEvent.PayloadByName("EventId"));
+            var eventName = traceEvent.PayloadByName("EventName")?.ToString();
+
+            Console.WriteLine($"{traceEvent.ActivityID} | {traceEvent.RelatedActivityID} | {eventName} | {eventId}");
+        }
+    }
+}

--- a/src/Poc.Sl.LoggerApp/EvenPipeProvidersHelper.cs
+++ b/src/Poc.Sl.LoggerApp/EvenPipeProvidersHelper.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Diagnostics.NETCore.Client;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Poc.Sl.LoggerApp
+{
+    internal static class EvenPipeProvidersHelper
+    {
+        public static List<EventPipeProvider> GetProviders()
+        {
+            return new List<EventPipeProvider>()
+            {
+                // Required providers:
+                // 1. Microsoft-Extensions-Logging
+                // 2. System.Threading.Tasks.TplEventSource
+                new EventPipeProvider(
+                    "Microsoft-Extensions-Logging",
+                    EventLevel.LogAlways,
+                    long.MaxValue),
+                new EventPipeProvider(
+                    "System.Threading.Tasks.TplEventSource",
+                    EventLevel.LogAlways,
+                    0x80),
+                // after last check, looks like we don't need this provider
+                //new EventPipeProvider(
+                //    "System-Net-Http",
+                //    EventLevel.LogAlways,
+                //    long.MaxValue),
+                //new EventPipeProvider(
+                //    "Microsoft.AspNetCore.HttpLogging",
+                //    EventLevel.LogAlways,
+                //    long.MaxValue),
+            };
+        }
+    }
+}

--- a/src/Poc.Sl.LoggerApp/FeatureFlags.cs
+++ b/src/Poc.Sl.LoggerApp/FeatureFlags.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Poc.Sl.LoggerApp
+{
+    public static class FeatureFlags
+    {
+        public static bool UseHttpClient => false;
+        public static bool UseAspnetCore => true;
+    }
+}

--- a/src/Poc.Sl.LoggerApp/HttpClientEventParserHelper.cs
+++ b/src/Poc.Sl.LoggerApp/HttpClientEventParserHelper.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Poc.Sl.LoggerApp
+{
+    internal static class HttpClientEventParserHelper
+    {
+        /// <summary>
+        /// System.Net.Http.HttpClient
+        /// </summary>
+        public static string LoggerNameBeggin => "System.Net.Http.HttpClient";
+
+        /// <summary>
+        /// LogicalHandler
+        /// </summary>
+        public static string LoggerNameEnd => "LogicalHandler";
+
+        /// <summary>
+        /// MessageJson
+        /// </summary>
+        public static string EventName => "MessageJson";
+
+        public static void Parse(TraceEvent traceEvent) 
+        {
+            var eventId = Convert.ToInt32(traceEvent.PayloadByName("EventId"));
+            var eventName = traceEvent.PayloadByName("EventName")?.ToString();
+
+            // ActivityId : Guid? 
+            // traceEvent.ActivityID - is correlation id.
+            // IMPORTANT:
+            // in debug mode, ActivityID will be not correct for eventId 101 and 103
+            Console.WriteLine($"{traceEvent.ActivityID} | {eventName}");
+            if (eventId == 100)
+                HttpClientEventParserHelper.ParseRequestPipelineStart(traceEvent);
+            else if (eventId == 101)
+                HttpClientEventParserHelper.ParseRequestPipelineEnd(traceEvent);
+            else if (eventId == 102)
+                HttpClientEventParserHelper.ParseRequestPipelineRequestHeader(traceEvent);
+            else if (eventId == 103)
+                HttpClientEventParserHelper.ParseRequestPipelineResponseHeader(traceEvent);
+        }
+
+        /// <summary>
+        /// eventId 100 - eventName RequestPipelineStart
+        /// </summary>
+        /// <param name="traceEvent"></param>
+        public static void ParseRequestPipelineStart(TraceEvent traceEvent)
+        {
+            var argumentsAsJson = traceEvent.PayloadByName("ArgumentsJson")?.ToString();
+            var arguments = JsonSerializer.Deserialize<Dictionary<string, string>>(argumentsAsJson);
+            var httpMethod = arguments["HttpMethod"];
+            var uri = arguments["Uri"];
+        }
+
+        /// <summary>
+        /// eventId 102 - eventName RequestPipelineRequestHeader
+        /// </summary>
+        /// <param name="traceEvent"></param>
+        public static void ParseRequestPipelineRequestHeader(TraceEvent traceEvent)
+        {
+            var headersAsText = traceEvent.PayloadByName("FormattedMessage")?.ToString();
+
+            var result = ParseHeaders(headersAsText);
+        }
+
+        /// <summary>
+        /// eventId 101 - eventName RequestPipelineEnd
+        /// </summary>
+        /// <param name="traceEvent"></param>
+        public static void ParseRequestPipelineEnd(TraceEvent traceEvent)
+        {
+            var argumentsAsJson = traceEvent.PayloadByName("ArgumentsJson")?.ToString();
+            var arguments = JsonSerializer.Deserialize<Dictionary<string, string>>(argumentsAsJson);
+            var elapsedMilliseconds = arguments["ElapsedMilliseconds"];
+            var statusCode = arguments["StatusCode"];
+        }
+
+        /// <summary>
+        /// eventId 103 - eventName RequestPipelineResponseHeader
+        /// </summary>
+        /// <param name="traceEvent"></param>
+        public static void ParseRequestPipelineResponseHeader(TraceEvent traceEvent)
+        {
+            var headersAsText = traceEvent.PayloadByName("FormattedMessage")?.ToString();
+            
+            var result = ParseHeaders(headersAsText);
+        }
+
+        private static string ParseHeaders(string headersAsText)
+        {
+            var headers = headersAsText.Split('\n').Skip(1);
+            var headersDictionary = new Dictionary<string, string>();
+            foreach (var header in headers)
+            {
+                var deviderIndex = header.IndexOf(':');
+                if (deviderIndex == -1)
+                {
+                    continue;
+                }
+                var key = header.Substring(0, deviderIndex);
+                var value = header.Substring(deviderIndex + 1);
+                headersDictionary.Add(key, value);
+            }
+            return JsonSerializer.Serialize(headersDictionary);
+        }
+    }
+}

--- a/src/Poc.Sl.LoggerApp/Poc.Sl.LoggerApp.csproj
+++ b/src/Poc.Sl.LoggerApp/Poc.Sl.LoggerApp.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.410101" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.421201" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Poc.Sl.LoggerApp/ProcessHelper.cs
+++ b/src/Poc.Sl.LoggerApp/ProcessHelper.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Diagnostics.Tracing.AutomatedAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Poc.Sl.LoggerApp
+{
+    internal static class ProcessHelper
+    {
+        public static string ProcessName { get; } = "Poc.Sl.HttpSenderApp";
+
+        public static int? GetProcessId(string processName)
+        {
+            var process = GetProcessWithRetry(processName);
+
+            return process != null 
+                ? process.Id 
+                : null;
+        }
+
+        private static System.Diagnostics.Process GetProcessWithRetry(string processName, int retryCount = 0)
+        {
+            var process = System.Diagnostics.Process
+                .GetProcessesByName(processName)
+                .FirstOrDefault();
+            
+            if (process == null && retryCount < 5)
+            {   
+                System.Threading.Thread.Sleep(1000);
+                Console.WriteLine($"Waiting {retryCount}");
+                process = GetProcessWithRetry(processName, retryCount++);
+            }
+
+            return process;
+        }
+    }
+}

--- a/src/Poc.Sl.LoggerApp/Program.cs
+++ b/src/Poc.Sl.LoggerApp/Program.cs
@@ -1,11 +1,8 @@
 ﻿using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
-using Poc.Sl.LoggerApp;
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using System.Diagnostics.Tracing;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 var processName = "Poc.Sl.HttpSenderApp";
 
@@ -29,13 +26,13 @@ var providers = new List<EventPipeProvider>()
         EventLevel.LogAlways,
         long.MaxValue),
     new EventPipeProvider(
-        "System.Net.Http",
+        "System-Net-Http",
         EventLevel.LogAlways,
         long.MaxValue),
-    new EventPipeProvider(
-        "Microsoft.AspNetCore.HttpLogging",
-        EventLevel.LogAlways,
-        long.MaxValue),
+    //new EventPipeProvider(
+    //    "Microsoft.AspNetCore.HttpLogging",
+    //    EventLevel.LogAlways,
+    //    long.MaxValue),
 };
 
 var client = new DiagnosticsClient(processId);
@@ -51,7 +48,8 @@ source.Dynamic.All += (TraceEvent obj) =>
     // to fix it we need to:
     // check if loggerName contains "System.Net.Http.HttpClient" and "LogicalHandler"
     // another way is create a regex
-    if (loggerName == "System.Net.Http.HttpClient.Default.LogicalHandler")
+    if (loggerName.Contains("System.Net.Http.HttpClient")
+        && loggerName.Contains("ClientHandler"))
     {
         if (obj.EventName != "MessageJson") 
         {

--- a/src/Poc.Sl.LoggerApp/Program.cs
+++ b/src/Poc.Sl.LoggerApp/Program.cs
@@ -1,146 +1,30 @@
 ﻿using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
+using Poc.Sl.LoggerApp;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Text.Json;
 
-var processName = "Poc.Sl.HttpSenderApp";
-
 // get process by name
-var process = Process
-    .GetProcessesByName(processName)
-    .FirstOrDefault();
+var process = ProcessHelper.GetProcessId(ProcessHelper.ProcessName);
 
-if (process == null) 
+if (!process.HasValue) 
 {
-    Console.WriteLine($"Process '{processName}' is not started");
+    Console.WriteLine($"Process '{ProcessHelper.ProcessName}' is not started");
     return;
 }
 
-var processId = process.Id;
+// prepare providers
+var providers = EvenPipeProvidersHelper.GetProviders();
 
-var providers = new List<EventPipeProvider>()
-{
-    new EventPipeProvider(
-        "Microsoft-Extensions-Logging",
-        EventLevel.LogAlways,
-        long.MaxValue),
-    new EventPipeProvider(
-        "System-Net-Http",
-        EventLevel.LogAlways,
-        long.MaxValue),
-    //new EventPipeProvider(
-    //    "Microsoft.AspNetCore.HttpLogging",
-    //    EventLevel.LogAlways,
-    //    long.MaxValue),
-};
-
-var client = new DiagnosticsClient(processId);
+// configure event source
+var client = new DiagnosticsClient(process.Value);
 using EventPipeSession session = client.StartEventPipeSession(providers, false);
 using var source = new EventPipeEventSource(session.EventStream);
 
-source.Dynamic.All += (TraceEvent obj) =>
-{
-    var loggerName = obj.PayloadByName("LoggerName")?.ToString();
+source.Dynamic.All += TraceEventParserHelper.Parse;
 
-    // this check convers only default httpClient. 
-    // named http clients will have "System.Net.Http.HttpClient.[http-client-name].LogicalHandler"
-    // to fix it we need to:
-    // check if loggerName contains "System.Net.Http.HttpClient" and "LogicalHandler"
-    // another way is create a regex
-    if (loggerName.Contains("System.Net.Http.HttpClient")
-        && loggerName.Contains("ClientHandler"))
-    {
-        if (obj.EventName != "MessageJson") 
-        {
-            return;
-        }
-
-        var eventId = Convert.ToInt32(obj.PayloadByName("EventId"));
-        var eventName = obj.PayloadByName("EventName")?.ToString();
-        var argumentsAsJson = obj.PayloadByName("ArgumentsJson")?.ToString();
-
-        // ActivityId : Guid? 
-        // if null - ignore
-        // if not null -> need to parse and use as correlation id
-        Console.WriteLine();
-        Console.WriteLine(eventName);
-        Console.WriteLine($"{obj.ThreadID} | ThreadID");
-        Console.WriteLine($"{obj.ActivityID} | ActivityID");
-        Console.WriteLine("- - - - - - - - - - - - - -");
-
-        // eventId 100 - eventName RequestPipelineStart
-        if (eventId == 100)
-        {
-            var arguments = JsonSerializer.Deserialize<Dictionary<string, string>>(argumentsAsJson);
-            var httpMethod = arguments["HttpMethod"];
-            var uri = arguments["Uri"];
-        }
-        // eventId 101 - eventName RequestPipelineEnd
-        else if (eventId == 101)
-        {
-            var arguments = JsonSerializer.Deserialize<Dictionary<string, string>>(argumentsAsJson);
-            var elapsedMilliseconds = arguments["ElapsedMilliseconds"];
-            var statusCode = arguments["StatusCode"];
-        }
-        // eventId 102 - eventName RequestPipelineRequestHeader
-        else if (eventId == 102)
-        {
-            var headersAsText = obj.PayloadByName("FormattedMessage")?.ToString();
-            var headers = headersAsText.Split('\n').Skip(1);
-            
-            var headersDictionary = new Dictionary<string, string>();
-
-            foreach (var header in headers) 
-            {
-                var deviderIndex = header.IndexOf(':');
-
-                if (deviderIndex == -1) 
-                {
-                    continue;
-                }
-
-                var key = header.Substring(0, deviderIndex);
-                var value = header.Substring(deviderIndex + 1);
-                headersDictionary.Add(key, value);
-            }
-        }
-        // eventId 103 - eventName RequestPipelineResponseHeader
-        else if (eventId == 103) 
-        {
-            var headersAsText = obj.PayloadByName("FormattedMessage")?.ToString();
-            var headers = headersAsText.Split('\n').Skip(1);
-
-            var headersDictionary = new Dictionary<string, string>();
-
-            foreach (var header in headers)
-            {
-                var deviderIndex = header.IndexOf(':');
-
-                if (deviderIndex == -1)
-                {
-                    continue;
-                }
-
-                var key = header.Substring(0, deviderIndex);
-                var value = header.Substring(deviderIndex + 1);
-                headersDictionary.Add(key, value);
-            }
-        }
-
-        var payload = new Dictionary<string, object>();
-
-        foreach (var name in obj.PayloadNames) 
-        {
-            payload.Add(name, obj.PayloadByName(name));
-        }
-    }
-    else if (loggerName == "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware") 
-    {
-        // process asp.net core request/response logs
-    }
-};
-
+// run
 try 
 {
     source.Process();

--- a/src/Poc.Sl.LoggerApp/TraceEventParserHelper.cs
+++ b/src/Poc.Sl.LoggerApp/TraceEventParserHelper.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Poc.Sl.LoggerApp
+{
+    internal static class TraceEventParserHelper
+    {
+        //public static string EventName => "MessageJson";
+
+        public static void Parse(TraceEvent traceEvent)
+        {
+            var loggerName = traceEvent.PayloadByName("LoggerName")?.ToString();
+
+            if (loggerName == null)
+                return;
+
+            // logger name can be:
+            // 1. System.Net.Http.HttpClient.Default.ClientHandler
+            // 2. System.Net.Http.HttpClient.[http-client-name].LogicalHandler
+            // Default - is default http client
+            // [http-client-name] - is named http client
+            if (FeatureFlags.UseHttpClient
+                && loggerName.Contains(HttpClientEventParserHelper.LoggerNameBeggin)
+                && loggerName.Contains(HttpClientEventParserHelper.LoggerNameEnd)
+                && traceEvent.EventName == HttpClientEventParserHelper.EventName)
+            {
+                HttpClientEventParserHelper.Parse(traceEvent);
+            }
+            else if (FeatureFlags.UseAspnetCore 
+                && loggerName == AspnetCoreEventParserHelper.LoggerName
+                && traceEvent.EventName == AspnetCoreEventParserHelper.EventName)
+            {
+                AspnetCoreEventParserHelper.Parse(traceEvent);
+            }
+        }   
+    }
+}


### PR DESCRIPTION
ActivityId was fixed.

TODO:
It's working only if you run the app view 'dotnet run'.
In VS activityId still wrong.